### PR TITLE
Update images.md

### DIFF
--- a/faq/images.md
+++ b/faq/images.md
@@ -1,3 +1,3 @@
 # Especificação de Imagens Suportadas via Integração
 
-As imagens na OLX tem que ter dimensões mínimas de 260 x 350 pixels. Os formatos de imagens suportados são JPG, GIF e PNG.
+As imagens na OLX tem que ter dimensões mínimas de 260 x 350 pixels (Largura x Altura). Os formatos de imagens suportados são JPG, GIF e PNG.


### PR DESCRIPTION
(Hi, I'm a Zap+ dev)

This PR writes explicitly that the 260 pixels is the minimum width, not height.
The fact that the minimum width is smaller than the minimum height is not so usual, so it was causing some confusion.